### PR TITLE
Added field 'totag' to enable statefull operations such as INVITE+INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Example fields file:
 	"viabranch": "$uuid",
 	"rport": ";rport",
 	"fromtag": "$uuid",
+	"totag": "",
 	"callid": "$uuid",
 	"cseqnum": "$randseq",
 	"date": "$daterfc1123",

--- a/sipexer.go
+++ b/sipexer.go
@@ -94,7 +94,7 @@ const (
 var templateDefaultText string = `{{.method}} {{.ruri}} SIP/2.0
 Via: SIP/2.0/{{.viaproto}} {{.viaaddr}}{{.rport}};{{.viaparams}}branch=z9hG4bKSG.{{.viabranch}}
 From: {{if .fromuri}}{{.fromuri}}{{else}}{{if .fname}}"{{.fname}}" {{end}}<sip:{{if .fuser}}{{.fuser}}@{{end}}{{.fdomain}}>{{end}};tag={{.fromtag}}
-To: {{if .touri}}{{.touri}}{{else}}{{if .tname}}"{{.tname}}" {{end}}<sip:{{if .tuser}}{{.tuser}}@{{end}}{{.tdomain}}>{{end}}
+To: {{if .touri}}{{.touri}}{{else}}{{if .tname}}"{{.tname}}" {{end}}<sip:{{if .tuser}}{{.tuser}}@{{end}}{{.tdomain}}>{{end}}{{if .totag}};tag={{.totag}}{{end}}
 Call-ID: {{.callid}}
 CSeq: {{.cseqnum}} {{.method}}
 {{if .subject}}Subject: {{.subject}}{{else}}$rmeol{{end}}
@@ -133,6 +133,7 @@ var templateDefaultJSONFields string = `{
 	"viaparams": "",
 	"rport": ";rport",
 	"fromtag": "$uuid",
+	"totag": "",
 	"callid": "$uuid",
 	"cseqnum": "$randseq",
 	"date": "$daterfc1123",


### PR DESCRIPTION
When you want to send an INFO during a call (ie after an INVITE), some header values from the INVITE/ACK frames need to be reused in the INFO frame (callid, ruri, to-tag, cseq+1), otherwise, the INFO frame can be rejected by the server.

It is possible to extract these headers from the "sipexer -invite" output :
```
sipexer -invite ... > output
CallID=`cat output | tr -d '\0' | grep "Call-ID" | head -n 1 | awk -F ' ' '{print $2}' | tr -d '\"\n\r'`
ruri=`cat output | tr -d '\0' | grep "ACK " | tail -n 1 | awk -F ' ' '{print $2}' | tr -d '\n\r'`
fromtag=`cat output | tr -d '\0' | grep "From:" | tail -n 1 | awk -F 'tag=' '{print $2}' | tr -d '\n\r'`
totag=`cat output | tr -d '\0' | grep "To:" | tail -n 1 | awk -F 'tag=' '{print $2}' | tr -d '\n\r'`
CSeq=$((`cat output | tr -d '\0' | grep "CSeq" | tail -n 1 | awk -F ' ' '{print $2}'`+1))
```
and to reuse them in the INFO message :
```
sipexer \
  -info 
  -field-val "fromtag:$fromtag" \
  -field-val "cseqnum:$CSeq" \ 
  -field-val "callid:$CallID" \
  -ruri "$ruri" \
  ...
```
With the server I am using, the to-tag provided with the INVITE/ACK is mandatory.
With this pull request, it is now also possible to use the "to-tag" information with this additional parameter :
```
  -field-val "totag:$totag" \
```