### PR TITLE
sipexer: don't output SIP on lower verbosity

### DIFF
--- a/sipexer.go
+++ b/sipexer.go
@@ -3372,6 +3372,9 @@ func SIPExerRandHexString(olen int) string {
 }
 
 func SIPExerMessagePrint(prefix string, smsg string, suffix string) {
+	if cliops.verbosity < SIPExerLogInfo {
+		return
+	}
 	if !cliops.colormessage {
 		fmt.Printf("%s%s%s", prefix, smsg, suffix)
 		return


### PR DESCRIPTION
Useful when running sipexer in background, for load test (e.g. via spawning multiple sipexer processes now).