### PR TITLE
SIPp like rate and csv user/pwd injector

### DIFF
--- a/sipexer.go
+++ b/sipexer.go
@@ -824,136 +824,136 @@ func main() {
 
 // SIPExerRunScenario builds fresh data for fresh scenario
 func SIPExerRunScenario(tplstr string) int {
-		var err error
-		var ok bool
-		var tret int
+	var err error
+	var ok bool
+	var tret int
 
-		tplfields := make(map[string]any)
+	tplfields := make(map[string]any)
 
-		SIPExerPrepareTemplateFields(tplfields)
+	SIPExerPrepareTemplateFields(tplfields)
 
-		var wsurlp *url.URL = nil
-		dstAddr := "udp:127.0.0.1:5060"
-		if len(flag.Args()) > 0 {
-			if len(flag.Args()) == 1 {
-				dstAddr = flag.Arg(0)
-				if strings.HasPrefix(dstAddr, "wss:") &&
-					!strings.HasPrefix(dstAddr, "wss://") {
-					dstAddr = strings.TrimPrefix(dstAddr, "wss:")
-					dstAddr = "wss://" + dstAddr
-				} else if strings.HasPrefix(dstAddr, "ws:") &&
-					!strings.HasPrefix(dstAddr, "ws://") {
-					dstAddr = strings.TrimPrefix(dstAddr, "ws:")
-					dstAddr = "ws://" + dstAddr
-				}
-				if strings.HasPrefix(dstAddr, "wss://") ||
-					strings.HasPrefix(dstAddr, "ws://") {
-					wsurlp, err = url.Parse(dstAddr)
-					if err != nil {
-						SIPExerPrintf(SIPExerLogError, "invalid websocket target: %v\n", dstAddr)
-						SIPExerExit(SIPExerErrWSURLFormat)
-					}
-					if strings.HasPrefix(dstAddr, "wss://") {
-						dstAddr = "wss:" + wsurlp.Host
-					} else {
-						dstAddr = "ws:" + wsurlp.Host
-					}
-				}
-			} else if len(flag.Args()) == 2 {
-				dstAddr = "udp:" + flag.Arg(0) + ":" + flag.Arg(1)
-			} else if len(flag.Args()) == 3 {
-				dstAddr = flag.Arg(0) + ":" + flag.Arg(1) + ":" + flag.Arg(2)
-			} else {
-				SIPExerPrintf(SIPExerLogError, "invalid number of arguments : %d [%v]\n",
-					len(flag.Args()), flag.Args())
-				SIPExerExit(SIPExerErrArgumentsNumber)
+	var wsurlp *url.URL = nil
+	dstAddr := "udp:127.0.0.1:5060"
+	if len(flag.Args()) > 0 {
+		if len(flag.Args()) == 1 {
+			dstAddr = flag.Arg(0)
+			if strings.HasPrefix(dstAddr, "wss:") &&
+				!strings.HasPrefix(dstAddr, "wss://") {
+				dstAddr = strings.TrimPrefix(dstAddr, "wss:")
+				dstAddr = "wss://" + dstAddr
+			} else if strings.HasPrefix(dstAddr, "ws:") &&
+				!strings.HasPrefix(dstAddr, "ws://") {
+				dstAddr = strings.TrimPrefix(dstAddr, "ws:")
+				dstAddr = "ws://" + dstAddr
 			}
-		}
-		var dstSockAddr = sgsip.SGSIPSocketAddress{}
-		var dstURI = sgsip.SGSIPURI{}
-		if sgsip.SGSIPParseSocketAddress(dstAddr, &dstSockAddr) != sgsip.SGSIPRetOK {
-			if sgsip.SGSIPParseURI(dstAddr, &dstURI) != sgsip.SGSIPRetOK {
-				SIPExerPrintf(SIPExerLogError, "invalid destination address: %s\n", dstAddr)
-				SIPExerExit(SIPExerErrDestinationFormat)
-			} else {
-				SIPExerPrintf(SIPExerLogDebug, "parsed SIP URI argument (%+v)\n", dstURI)
-				sgsip.SGSIPURIToSocketAddress(&dstURI, &dstSockAddr)
-			}
-		} else {
-			SIPExerPrintf(SIPExerLogDebug, "parsed socket address argument (%+v)\n", dstSockAddr)
-			if cliops.setuser {
-				_, ok = tplfields["tuser"]
-				if ok {
-					sgsip.SGSocketAddressToSIPURI(&dstSockAddr, fmt.Sprint(tplfields["tuser"]), 0, &dstURI)
+			if strings.HasPrefix(dstAddr, "wss://") ||
+				strings.HasPrefix(dstAddr, "ws://") {
+				wsurlp, err = url.Parse(dstAddr)
+				if err != nil {
+					SIPExerPrintf(SIPExerLogError, "invalid websocket target: %v\n", dstAddr)
+					SIPExerExit(SIPExerErrWSURLFormat)
+				}
+				if strings.HasPrefix(dstAddr, "wss://") {
+					dstAddr = "wss:" + wsurlp.Host
 				} else {
-					sgsip.SGSocketAddressToSIPURI(&dstSockAddr, cliops.ruser, 0, &dstURI)
+					dstAddr = "ws:" + wsurlp.Host
 				}
+			}
+		} else if len(flag.Args()) == 2 {
+			dstAddr = "udp:" + flag.Arg(0) + ":" + flag.Arg(1)
+		} else if len(flag.Args()) == 3 {
+			dstAddr = flag.Arg(0) + ":" + flag.Arg(1) + ":" + flag.Arg(2)
+		} else {
+			SIPExerPrintf(SIPExerLogError, "invalid number of arguments : %d [%v]\n",
+				len(flag.Args()), flag.Args())
+			SIPExerExit(SIPExerErrArgumentsNumber)
+		}
+	}
+	var dstSockAddr = sgsip.SGSIPSocketAddress{}
+	var dstURI = sgsip.SGSIPURI{}
+	if sgsip.SGSIPParseSocketAddress(dstAddr, &dstSockAddr) != sgsip.SGSIPRetOK {
+		if sgsip.SGSIPParseURI(dstAddr, &dstURI) != sgsip.SGSIPRetOK {
+			SIPExerPrintf(SIPExerLogError, "invalid destination address: %s\n", dstAddr)
+			SIPExerExit(SIPExerErrDestinationFormat)
+		} else {
+			SIPExerPrintf(SIPExerLogDebug, "parsed SIP URI argument (%+v)\n", dstURI)
+			sgsip.SGSIPURIToSocketAddress(&dstURI, &dstSockAddr)
+		}
+	} else {
+		SIPExerPrintf(SIPExerLogDebug, "parsed socket address argument (%+v)\n", dstSockAddr)
+		if cliops.setuser {
+			_, ok = tplfields["tuser"]
+			if ok {
+				sgsip.SGSocketAddressToSIPURI(&dstSockAddr, fmt.Sprint(tplfields["tuser"]), 0, &dstURI)
 			} else {
 				sgsip.SGSocketAddressToSIPURI(&dstSockAddr, cliops.ruser, 0, &dstURI)
 			}
-		}
-		if len(cliops.ruri) > 0 {
-			tplfields["ruri"] = cliops.ruri
 		} else {
-			_, ok = tplfields["ruri"]
-			if !ok {
-				tplfields["ruri"] = dstURI.Val
-			}
+			sgsip.SGSocketAddressToSIPURI(&dstSockAddr, cliops.ruser, 0, &dstURI)
 		}
-		if cliops.setdomains {
-			var rURI = sgsip.SGSIPURI{}
-			if sgsip.SGSIPParseURI(fmt.Sprint(tplfields["ruri"]), &rURI) != sgsip.SGSIPRetOK {
-				SIPExerPrintf(SIPExerLogError, "invalid ruri: %v\n", tplfields["ruri"])
-				SIPExerExit(SIPExerErrURIFormat)
-			}
-			tplfields["fdomain"] = rURI.Addr
-			tplfields["tdomain"] = rURI.Addr
+	}
+	if len(cliops.ruri) > 0 {
+		tplfields["ruri"] = cliops.ruri
+	} else {
+		_, ok = tplfields["ruri"]
+		if !ok {
+			tplfields["ruri"] = dstURI.Val
 		}
+	}
+	if cliops.setdomains {
+		var rURI = sgsip.SGSIPURI{}
+		if sgsip.SGSIPParseURI(fmt.Sprint(tplfields["ruri"]), &rURI) != sgsip.SGSIPRetOK {
+			SIPExerPrintf(SIPExerLogError, "invalid ruri: %v\n", tplfields["ruri"])
+			SIPExerExit(SIPExerErrURIFormat)
+		}
+		tplfields["fdomain"] = rURI.Addr
+		tplfields["tdomain"] = rURI.Addr
+	}
 
-		if cliops.templaterun {
-			lTAddr := ""
-			if len(cliops.localaddress) > 0 {
-				lTAddr = cliops.localaddress
-			} else {
-				lTAddr = "127.0.0.1:55060"
-			}
-			var msgVal sgsip.SGSIPMessage = sgsip.SGSIPMessage{}
-			var smsg string = ""
-			tret = SIPExerPrepareMessage(tplstr, tplfields, dstSockAddr.Proto, lTAddr, dstSockAddr.Addr+":"+dstSockAddr.Port, &msgVal)
-			if tret != 0 {
-				SIPExerExit(tret)
-			}
-			smsg = msgVal.Data
-			msgVal = sgsip.SGSIPMessage{}
-			if sgsip.SGSIPParseMessage(smsg, &msgVal) != sgsip.SGSIPRetOK {
-				SIPExerPrintf(SIPExerLogError, "failed to parse sip message\n%+v\n\n", smsg)
-				SIPExerExit(SIPExerErrSIPMessageFormat)
-			}
-			if cliops.verbosity > 0 {
-				fmt.Printf("%+v\n\n", smsg)
-				fmt.Printf("%+v\n\n", msgVal)
-			}
-
-			if cliops.runcount > 1 {
-				return SIPExerRetDone
-			}
-			SIPExerExit(SIPExerRetDone)
-		}
-
-		if !SIPExerTargetProtoSupported(dstSockAddr.ProtoId) {
-			SIPExerPrintf(SIPExerLogError, "transport protocol not supported yet for target %s\n", dstAddr)
-			SIPExerExit(SIPExerErrProtocolUnsuported)
-		}
-		if cliops.callusers {
-			tret = SIPExerRunCallUsers(dstSockAddr, wsurlp, tplstr, tplfields)
-		} else if cliops.callself {
-			tret = SIPExerRunCallSelf(dstSockAddr, wsurlp, tplstr, tplfields)
-		} else if cliops.registerfirst {
-			tret = SIPExerRunRegisterFirst(dstSockAddr, wsurlp, tplstr, tplfields)
+	if cliops.templaterun {
+		lTAddr := ""
+		if len(cliops.localaddress) > 0 {
+			lTAddr = cliops.localaddress
 		} else {
-			tret = SIPExerRunSend(dstSockAddr, wsurlp, tplstr, tplfields)
+			lTAddr = "127.0.0.1:55060"
 		}
-		return tret
+		var msgVal sgsip.SGSIPMessage = sgsip.SGSIPMessage{}
+		var smsg string = ""
+		tret = SIPExerPrepareMessage(tplstr, tplfields, dstSockAddr.Proto, lTAddr, dstSockAddr.Addr+":"+dstSockAddr.Port, &msgVal)
+		if tret != 0 {
+			SIPExerExit(tret)
+		}
+		smsg = msgVal.Data
+		msgVal = sgsip.SGSIPMessage{}
+		if sgsip.SGSIPParseMessage(smsg, &msgVal) != sgsip.SGSIPRetOK {
+			SIPExerPrintf(SIPExerLogError, "failed to parse sip message\n%+v\n\n", smsg)
+			SIPExerExit(SIPExerErrSIPMessageFormat)
+		}
+		if cliops.verbosity > 0 {
+			fmt.Printf("%+v\n\n", smsg)
+			fmt.Printf("%+v\n\n", msgVal)
+		}
+
+		if cliops.runcount > 1 {
+			return SIPExerRetDone
+		}
+		SIPExerExit(SIPExerRetDone)
+	}
+
+	if !SIPExerTargetProtoSupported(dstSockAddr.ProtoId) {
+		SIPExerPrintf(SIPExerLogError, "transport protocol not supported yet for target %s\n", dstAddr)
+		SIPExerExit(SIPExerErrProtocolUnsuported)
+	}
+	if cliops.callusers {
+		tret = SIPExerRunCallUsers(dstSockAddr, wsurlp, tplstr, tplfields)
+	} else if cliops.callself {
+		tret = SIPExerRunCallSelf(dstSockAddr, wsurlp, tplstr, tplfields)
+	} else if cliops.registerfirst {
+		tret = SIPExerRunRegisterFirst(dstSockAddr, wsurlp, tplstr, tplfields)
+	} else {
+		tret = SIPExerRunSend(dstSockAddr, wsurlp, tplstr, tplfields)
+	}
+	return tret
 }
 
 // SIPExerRunBatch implements an open-loop, SIPp-style run-batch injector

--- a/sipexer.go
+++ b/sipexer.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -211,6 +212,7 @@ type SIPExerDialog struct {
 	Resend       bool
 	SkipAuth     bool
 	CallSelfBye  bool
+	SessionWait  int
 
 	TargetHostPort string
 	TargetAFProto  string
@@ -367,6 +369,8 @@ type CLIOptions struct {
 	colormessage     bool
 	sessionwait      int
 	runcount         int
+	runbatch         int
+	runbatchinterval int
 	helpcommands     bool
 	dnssrvprint      bool
 	indialogdns      bool
@@ -464,6 +468,8 @@ var cliops = CLIOptions{
 	colormessage:     false,
 	sessionwait:      0,
 	runcount:         1,
+	runbatch:         0,
+	runbatchinterval: 1000,
 	dnssrvprint:      false,
 	indialogdns:      false,
 	lateoffer:        false,
@@ -694,6 +700,10 @@ func init() {
 	flag.IntVar(&cliops.af, "af", cliops.af, "enforce address family for socket (4 or 6)")
 	flag.IntVar(&cliops.runcount, "rc", cliops.runcount, "how many times to recreate and send the message")
 	flag.IntVar(&cliops.runcount, "run-count", cliops.runcount, "how many times to recreate and send the message")
+	flag.IntVar(&cliops.runbatch, "rb", cliops.runbatch, "run-batch injector: number of scenarios to spawn on each interval (basic send scenarios only)")
+	flag.IntVar(&cliops.runbatch, "run-batch", cliops.runbatch, "run-batch injector: number of scenarios to spawn on each interval (basic send scenarios only)")
+	flag.IntVar(&cliops.runbatchinterval, "rbi", cliops.runbatchinterval, "run-batch injector: milliseconds between spawning run batches")
+	flag.IntVar(&cliops.runbatchinterval, "run-batch-interval", cliops.runbatchinterval, "run-batch injector: milliseconds between spawning run batches")
 	flag.IntVar(&cliops.ringtime, "ring-time", cliops.ringtime, "ringing time in milliseconds before 200 OK in self-call mode")
 	flag.IntVar(&cliops.ringtime, "rt", cliops.ringtime, "ringing time in milliseconds before 200 OK in self-call mode")
 	flag.IntVar(&cliops.callduration, "call-duration", cliops.callduration, "call duration in milliseconds before BYE in self-call mode")
@@ -727,8 +737,6 @@ func init() {
 
 // sipexer application
 func main() {
-	var err error
-	var ok bool
 	var tret int
 
 	flag.Parse()
@@ -801,7 +809,25 @@ func main() {
 		cliops.localaddress = ""
 	}
 
+	// run-batch injector
+	if cliops.runbatch > 0 {
+		tret = SIPExerRunBatch(tplstr)
+		SIPExerExit(tret)
+	}
+
 	for r := 0; r < cliops.runcount; r++ {
+		tret = SIPExerRunScenario(tplstr)
+	}
+
+	SIPExerExit(tret)
+}
+
+// SIPExerRunScenario builds fresh data for fresh scenario
+func SIPExerRunScenario(tplstr string) int {
+		var err error
+		var ok bool
+		var tret int
+
 		tplfields := make(map[string]any)
 
 		SIPExerPrepareTemplateFields(tplfields)
@@ -909,8 +935,7 @@ func main() {
 			}
 
 			if cliops.runcount > 1 {
-				tret = SIPExerRetDone
-				continue
+				return SIPExerRetDone
 			}
 			SIPExerExit(SIPExerRetDone)
 		}
@@ -928,9 +953,66 @@ func main() {
 		} else {
 			tret = SIPExerRunSend(dstSockAddr, wsurlp, tplstr, tplfields)
 		}
+		return tret
+}
+
+// SIPExerRunBatch implements an open-loop, SIPp-style run-batch injector
+func SIPExerRunBatch(tplstr string) int {
+	if cliops.runbatch <= 0 {
+		// unreachable via the -rb>0 opt-in gate in main, kept as a defensive guard
+		SIPExerPrintf(SIPExerLogError, "run-batch injector requires -rb (>0)\n")
+		return SIPExerRetErr
+	}
+	if cliops.runbatchinterval <= 0 {
+		SIPExerPrintf(SIPExerLogError, "run-batch injector requires -rbi (>0), got %d\n", cliops.runbatchinterval)
+		return SIPExerRetErr
+	}
+	if cliops.callself || cliops.callusers || cliops.registerfirst {
+		SIPExerPrintf(SIPExerLogError, "run-batch injector (-rb/-rbi) supports basic send scenarios only, not call-self/call-user/register-first\n")
+		return SIPExerRetErr
+	}
+	if cliops.templaterun {
+		SIPExerPrintf(SIPExerLogError, "run-batch injector (-rb/-rbi) cannot be combined with template-run\n")
+		return SIPExerRetErr
 	}
 
-	SIPExerExit(tret)
+	// number of batches, rounded up; the last batch is trimmed so exactly rc scenarios run
+	nbatches := (cliops.runcount + cliops.runbatch - 1) / cliops.runbatch
+	if nbatches <= 0 {
+		SIPExerPrintf(SIPExerLogError, "run-batch injector: -rc (%d) must be > 0\n", cliops.runcount)
+		return SIPExerRetErr
+	}
+
+	warmFields := make(map[string]any)
+	SIPExerPrepareTemplateFields(warmFields)
+	if len(cliops.authuser) == 0 {
+		cliops.authuser = fmt.Sprint(warmFields["fuser"])
+	}
+
+	SIPExerPrintf(SIPExerLogInfo, "run-batch injector: %d batches of up to %d every %d ms, total %d\n",
+		nbatches, cliops.runbatch, cliops.runbatchinterval, cliops.runcount)
+
+	var wg sync.WaitGroup
+	spawned := 0
+	for b := 0; b < nbatches; b++ {
+		batch := cliops.runbatch
+		if spawned+batch > cliops.runcount {
+			batch = cliops.runcount - spawned
+		}
+		for i := 0; i < batch; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				SIPExerRunScenario(tplstr)
+			}()
+		}
+		spawned += batch
+		if b < nbatches-1 {
+			time.Sleep(time.Duration(cliops.runbatchinterval) * time.Millisecond)
+		}
+	}
+	wg.Wait()
+	return SIPExerRetOK
 }
 
 func SIPExerExit(ret int) {
@@ -971,12 +1053,6 @@ func SIPExerTargetProtoSupported(protoId int) bool {
 }
 
 func SIPExerRunSend(dstSockAddr sgsip.SGSIPSocketAddress, wsurlp *url.URL, tplstr string, tplfields map[string]any) int {
-	// restore sessionwait needed for a subsequent run-count (-rc) iteration
-	svSessionWait := cliops.sessionwait
-	defer func() {
-		cliops.sessionwait = svSessionWait
-	}()
-
 	tchan := make(chan int, 1)
 	if dstSockAddr.ProtoId == sgsip.ProtoTCP {
 		go SIPExerSendTCP(dstSockAddr, tplstr, tplfields, tchan)
@@ -1573,7 +1649,9 @@ func SIPExerPrepareTemplateFields(tplfields map[string]any) int {
 			SIPExerPrintf(SIPExerLogError, "error: %v\n", err)
 			SIPExerExit(SIPExerErrFieldsDefaultFormat)
 		}
-		cliops.fieldseval = true
+		if !cliops.fieldseval {
+			cliops.fieldseval = true
+		}
 	} else {
 		tplfields = templateFields["FIELDS:EMPTY"]
 	}
@@ -2259,7 +2337,7 @@ func SIPExerDialogReadBytes(seDlg *SIPExerDialog) int {
 func SIPExerSessionWaitAndRead(seDlg *SIPExerDialog) int {
 	var smsg string = ""
 	tStart := time.Now()
-	tWait := cliops.sessionwait
+	tWait := seDlg.SessionWait
 	for {
 		SIPExerPrintf(SIPExerLogInfo, "waiting for %d milliseconds\n", tWait)
 
@@ -2309,7 +2387,7 @@ func SIPExerSessionWaitAndRead(seDlg *SIPExerDialog) int {
 				}
 			}
 		}
-		tWait = int(tStart.UnixMilli() + int64(cliops.sessionwait) - tNow.UnixMilli())
+		tWait = int(tStart.UnixMilli() + int64(seDlg.SessionWait) - tNow.UnixMilli())
 	}
 	return SIPExerRetOK
 }
@@ -2502,6 +2580,9 @@ func SIPExerDialogLoop(tplstr string, tplfields map[string]any, seDlg *SIPExerDi
 	if len(cliops.authuser) == 0 {
 		cliops.authuser = fmt.Sprint(tplfields["fuser"])
 	}
+
+	// per-dialog copy of sessionwait
+	seDlg.SessionWait = cliops.sessionwait
 
 	seDlg.FirstRequest = new(sgsip.SGSIPMessage)
 	ret := SIPExerPrepareMessage(tplstr, tplfields, seDlg.Proto, seDlg.LocalAddr, seDlg.TargetAddr, seDlg.FirstRequest)
@@ -2802,7 +2883,7 @@ func SIPExerDialogLoop(tplstr string, tplfields map[string]any, seDlg *SIPExerDi
 				SIPExerPrintf(SIPExerLogInfo, "sending to %s %s: [[---", seDlg.Proto, seDlg.TargetAddr)
 				SIPExerMessagePrint("\n\n", sack, "\n")
 				SIPExerPrintf(SIPExerLogInfo, "---]]\n\n")
-				if cliops.sessionwait > 0 && ret >= 200 && ret < 300 {
+				if seDlg.SessionWait > 0 && ret >= 200 && ret < 300 {
 					// store 200-ack in dialog structure
 					seDlg.AckRequest = new(sgsip.SGSIPMessage)
 					if sgsip.SGSIPParseMessage(sack, seDlg.AckRequest) != sgsip.SGSIPRetOK {
@@ -2864,11 +2945,11 @@ func SIPExerDialogLoop(tplstr string, tplfields map[string]any, seDlg *SIPExerDi
 					continue
 				}
 			}
-			if cliops.sessionwait > 0 && ret >= 200 && ret < 300 &&
+			if seDlg.SessionWait > 0 && ret >= 200 && ret < 300 &&
 				(cliops.invite || cliops.register || cliops.subscribesession) {
 				SIPExerSessionWaitAndRead(seDlg)
 				smsg = ""
-				cliops.sessionwait = 0
+				seDlg.SessionWait = 0
 				if cliops.register {
 					sgsip.SGSIPMessageViaUpdate(seDlg.FirstRequest)
 					sgsip.SGSIPMessageCSeqUpdate(seDlg.FirstRequest, 1)

--- a/sipexer.go
+++ b/sipexer.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/csv"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -46,6 +47,8 @@ const (
 	// errors
 	SIPExerErrTemplateRead        = -1000
 	SIPExerErrTemplateData        = -1001
+	SIPExerErrAuthCSVRead         = -1010
+	SIPExerErrAuthCSVFormat       = -1011
 	SIPExerErrFieldsFileRead      = -1020
 	SIPExerErrFieldsFileFormat    = -1021
 	SIPExerErrFieldsDefaultFormat = -1022
@@ -213,6 +216,8 @@ type SIPExerDialog struct {
 	SkipAuth     bool
 	CallSelfBye  bool
 	SessionWait  int
+	AuthUser     string
+	AuthPassword string
 
 	TargetHostPort string
 	TargetAFProto  string
@@ -354,6 +359,7 @@ type CLIOptions struct {
 	wsproto          string
 	authuser         string
 	authapassword    string
+	authcsv          string
 	authalg          string
 	noval            string
 	contacturi       string
@@ -440,6 +446,7 @@ var cliops = CLIOptions{
 	wsproto:          "sip",
 	authuser:         "",
 	authapassword:    "",
+	authcsv:          "",
 	authalg:          "first",
 	noval:            "no",
 	contacturi:       "",
@@ -582,6 +589,8 @@ func init() {
 	flag.StringVar(&cliops.authalg, "auth-alg", cliops.authalg, "authenticate header selection: first | last | strong | algorithm-name")
 	flag.StringVar(&cliops.authuser, "au", cliops.authuser, "authentication user")
 	flag.StringVar(&cliops.authuser, "auth-user", cliops.authuser, "authentication user")
+	flag.StringVar(&cliops.authcsv, "acsv", cliops.authcsv, "path to a csv file with 'user,password' per line")
+	flag.StringVar(&cliops.authcsv, "auth-csv", cliops.authcsv, "path to a csv file with 'user,password' per line")
 	flag.StringVar(&cliops.body, "mb", cliops.body, "message body")
 	flag.StringVar(&cliops.body, "message-body", cliops.body, "message body")
 	flag.StringVar(&cliops.contacturi, "contact-uri", cliops.contacturi, "contact header uri")
@@ -809,6 +818,11 @@ func main() {
 		cliops.localaddress = ""
 	}
 
+	// auth csv injector
+	if tret := SIPExerLoadAuthCSV(); tret != SIPExerRetOK {
+		SIPExerExit(tret)
+	}
+
 	// run-batch injector
 	if cliops.runbatch > 0 {
 		tret = SIPExerRunBatch(tplstr)
@@ -816,14 +830,14 @@ func main() {
 	}
 
 	for r := 0; r < cliops.runcount; r++ {
-		tret = SIPExerRunScenario(tplstr)
+		tret = SIPExerRunScenario(tplstr, r)
 	}
 
 	SIPExerExit(tret)
 }
 
 // SIPExerRunScenario builds fresh data for fresh scenario
-func SIPExerRunScenario(tplstr string) int {
+func SIPExerRunScenario(tplstr string, scenarioIndex int) int {
 	var err error
 	var ok bool
 	var tret int
@@ -831,6 +845,14 @@ func SIPExerRunScenario(tplstr string) int {
 	tplfields := make(map[string]any)
 
 	SIPExerPrepareTemplateFields(tplfields)
+
+	// per-scenario credential injection from --auth-csv file
+	if len(authCredentials) > 0 {
+		ac := authCredentials[scenarioIndex%len(authCredentials)]
+		tplfields["fuser"] = ac.User
+		tplfields["authuser"] = ac.User
+		tplfields["authpassword"] = ac.Password
+	}
 
 	var wsurlp *url.URL = nil
 	dstAddr := "udp:127.0.0.1:5060"
@@ -1000,10 +1022,11 @@ func SIPExerRunBatch(tplstr string) int {
 			batch = cliops.runcount - spawned
 		}
 		for i := 0; i < batch; i++ {
+			scenario_index := spawned + i
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				SIPExerRunScenario(tplstr)
+				SIPExerRunScenario(tplstr, scenario_index)
 			}()
 		}
 		spawned += batch
@@ -1280,6 +1303,59 @@ func SIPExerRuntimeApply(st SIPExerRuntimeState) {
 		iVarMap[k] = v
 	}
 	templateBody = st.templateBodyVal
+}
+
+// SIPExerAuthCredential is one 'user,password' row loaded from --auth-csv file
+type SIPExerAuthCredential struct {
+	User     string
+	Password string
+}
+
+// authCredentials holds all rows loaded from --auth-csv file
+var authCredentials []SIPExerAuthCredential
+
+// SIPExerLoadAuthCSV loads the --auth-csv file into authCredentials
+func SIPExerLoadAuthCSV() int {
+	if len(cliops.authcsv) == 0 {
+		return SIPExerRetOK
+	}
+	f, err := os.Open(cliops.authcsv)
+	if err != nil {
+		SIPExerPrintf(SIPExerLogError, "failed to open auth csv file %s: %v\n", cliops.authcsv, err)
+		return SIPExerErrAuthCSVRead
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.Comment = '#'
+	r.TrimLeadingSpace = true
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		SIPExerPrintf(SIPExerLogError, "failed to parse auth csv file %s: %v\n", cliops.authcsv, err)
+		return SIPExerErrAuthCSVFormat
+	}
+	for i, rec := range records {
+		if len(rec) < 2 {
+			SIPExerPrintf(SIPExerLogError, "auth csv %s line %d: expected 'user,password', got %d field(s)\n",
+				cliops.authcsv, i+1, len(rec))
+			return SIPExerErrAuthCSVFormat
+		}
+		user := strings.TrimSpace(rec[0])
+		if len(user) == 0 {
+			continue
+		}
+		authCredentials = append(authCredentials, SIPExerAuthCredential{
+			User:     user,
+			Password: rec[1],
+		})
+	}
+	if len(authCredentials) == 0 {
+		SIPExerPrintf(SIPExerLogError, "auth csv file %s has no usable 'user,password' rows\n", cliops.authcsv)
+		return SIPExerErrAuthCSVFormat
+	}
+	SIPExerPrintf(SIPExerLogInfo, "loaded %d credential(s) from auth csv %s\n", len(authCredentials), cliops.authcsv)
+	return SIPExerRetOK
 }
 
 func SIPExerLoadTemplates() (string, error) {
@@ -2136,7 +2212,7 @@ func SIPExerPrepareMessage(tplstr string, tplfields map[string]any, rProto strin
 	return SIPExerRetOK
 }
 
-func SIPExerProcessResponse(msgVal *sgsip.SGSIPMessage, rmsg []byte, sipRes *sgsip.SGSIPMessage, skipauth *bool, smsg *string, sack *string) int {
+func SIPExerProcessResponse(msgVal *sgsip.SGSIPMessage, rmsg []byte, sipRes *sgsip.SGSIPMessage, skipauth *bool, smsg *string, sack *string, authUser string, authPassword string) int {
 	if sgsip.SGSIPParseMessage(string(rmsg), sipRes) != sgsip.SGSIPRetOK {
 		SIPExerPrintf(SIPExerLogError, "failed to parse sip response\n%+v\n\n", string(rmsg))
 		return SIPExerErrSIPMessageFormat
@@ -2164,7 +2240,7 @@ func SIPExerProcessResponse(msgVal *sgsip.SGSIPMessage, rmsg []byte, sipRes *sgs
 		if *skipauth {
 			return sipRes.FLine.Code
 		}
-		if len(cliops.authapassword) == 0 && len(cliops.akakey) == 0 {
+		if len(authPassword) == 0 && len(cliops.akakey) == 0 {
 			return sipRes.FLine.Code
 		}
 		hparams := map[string]string(nil)
@@ -2226,7 +2302,7 @@ func SIPExerProcessResponse(msgVal *sgsip.SGSIPMessage, rmsg []byte, sipRes *sgs
 			}
 		} else {
 			var err error
-			authResponse, err = sgsip.SGAuthBuildResponseBody(cliops.authuser, cliops.authapassword, cliops.ha1, hparams)
+			authResponse, err = sgsip.SGAuthBuildResponseBody(authUser, authPassword, cliops.ha1, hparams)
 			if err != nil {
 				SIPExerPrintf(SIPExerLogError, "failed to build auth response header (%v)\n", err)
 				return SIPExerErrHeaderAuthFailure
@@ -2577,8 +2653,21 @@ func SIPExerDialogLoop(tplstr string, tplfields map[string]any, seDlg *SIPExerDi
 	var err error
 	var wmsg []byte
 
-	if len(cliops.authuser) == 0 {
-		cliops.authuser = fmt.Sprint(tplfields["fuser"])
+	// if no --auth-csv, fall back to the global -au/-ap values.
+	seDlg.AuthUser = cliops.authuser
+	seDlg.AuthPassword = cliops.authapassword
+	if v, ok := tplfields["authuser"]; ok {
+		if s := fmt.Sprint(v); len(s) > 0 {
+			seDlg.AuthUser = s
+		}
+	}
+	if v, ok := tplfields["authpassword"]; ok {
+		if s := fmt.Sprint(v); len(s) > 0 {
+			seDlg.AuthPassword = s
+		}
+	}
+	if len(seDlg.AuthUser) == 0 {
+		seDlg.AuthUser = fmt.Sprint(tplfields["fuser"])
 	}
 
 	// per-dialog copy of sessionwait
@@ -2678,7 +2767,7 @@ func SIPExerDialogLoop(tplstr string, tplfields map[string]any, seDlg *SIPExerDi
 			SIPExerMessagePrint("\n\n", string(seDlg.RecvBuf[:seDlg.RecvN]), "\n")
 			SIPExerPrintf(SIPExerLogInfo, "---]]\n")
 			seDlg.LastResponse = new(sgsip.SGSIPMessage)
-			ret = SIPExerProcessResponse(seDlg.FirstRequest, seDlg.RecvBuf[:seDlg.RecvN], seDlg.LastResponse, &seDlg.SkipAuth, &smsg, &sack)
+			ret = SIPExerProcessResponse(seDlg.FirstRequest, seDlg.RecvBuf[:seDlg.RecvN], seDlg.LastResponse, &seDlg.SkipAuth, &smsg, &sack, seDlg.AuthUser, seDlg.AuthPassword)
 			if ret < 0 {
 				return ret
 			}
@@ -2993,7 +3082,7 @@ func SIPExerDialogLoop(tplstr string, tplfields map[string]any, seDlg *SIPExerDi
 					if seDlg.SkipAuth {
 						return ret
 					}
-					if len(cliops.authapassword) == 0 && len(cliops.akakey) == 0 {
+					if len(seDlg.AuthPassword) == 0 && len(cliops.akakey) == 0 {
 						return ret
 					}
 					// authentication - send the new message


### PR DESCRIPTION
The new -rb and -rbi cli params will allow spawning simultaneous (uac) scenarios, using go routines.
This is similar to how SIPp manages the rate of calls. For example, to send 11 CPS, 100 total calls need: rc = 100, rb = 11, rbi = 1000 (ms)

Few notes:
- exiting functionality, outside the new cli params, should be the same
- full AI used to develop, review, test for other scenarios then my usual one; since my go skills are very basic, I tried to question it as much as possible 
- go routines eat RAM depending on how big the load test is (rb), but no RAM leaks spotted in my default, usual load test  
- i splitted this in 2 commits to be more easy to review: 2'nd commit is just gofmt
