### PR TITLE
add csv row target

### DIFF
--- a/sipexer.go
+++ b/sipexer.go
@@ -863,28 +863,6 @@ func SIPExerRunScenario(tplstr string, scenarioIndex int) int {
 	} else if len(flag.Args()) > 0 {
 		if len(flag.Args()) == 1 {
 			dstAddr = flag.Arg(0)
-			if strings.HasPrefix(dstAddr, "wss:") &&
-				!strings.HasPrefix(dstAddr, "wss://") {
-				dstAddr = strings.TrimPrefix(dstAddr, "wss:")
-				dstAddr = "wss://" + dstAddr
-			} else if strings.HasPrefix(dstAddr, "ws:") &&
-				!strings.HasPrefix(dstAddr, "ws://") {
-				dstAddr = strings.TrimPrefix(dstAddr, "ws:")
-				dstAddr = "ws://" + dstAddr
-			}
-			if strings.HasPrefix(dstAddr, "wss://") ||
-				strings.HasPrefix(dstAddr, "ws://") {
-				wsurlp, err = url.Parse(dstAddr)
-				if err != nil {
-					SIPExerPrintf(SIPExerLogError, "invalid websocket target: %v\n", dstAddr)
-					SIPExerExit(SIPExerErrWSURLFormat)
-				}
-				if strings.HasPrefix(dstAddr, "wss://") {
-					dstAddr = "wss:" + wsurlp.Host
-				} else {
-					dstAddr = "ws:" + wsurlp.Host
-				}
-			}
 		} else if len(flag.Args()) == 2 {
 			dstAddr = "udp:" + flag.Arg(0) + ":" + flag.Arg(1)
 		} else if len(flag.Args()) == 3 {
@@ -895,6 +873,25 @@ func SIPExerRunScenario(tplstr string, scenarioIndex int) int {
 			SIPExerExit(SIPExerErrArgumentsNumber)
 		}
 	}
+
+	// normalize ws/wss target
+	if strings.HasPrefix(dstAddr, "wss:") && !strings.HasPrefix(dstAddr, "wss://") {
+		dstAddr = "wss://" + strings.TrimPrefix(dstAddr, "wss:")
+	} else if strings.HasPrefix(dstAddr, "ws:") && !strings.HasPrefix(dstAddr, "ws://") {
+		dstAddr = "ws://" + strings.TrimPrefix(dstAddr, "ws:")
+	}
+	if strings.HasPrefix(dstAddr, "wss://") || strings.HasPrefix(dstAddr, "ws://") {
+		if wsurlp, err = url.Parse(dstAddr); err != nil {
+			SIPExerPrintf(SIPExerLogError, "invalid websocket target: %v\n", dstAddr)
+			SIPExerExit(SIPExerErrWSURLFormat)
+		}
+		if strings.HasPrefix(dstAddr, "wss://") {
+			dstAddr = "wss:" + wsurlp.Host
+		} else {
+			dstAddr = "ws:" + wsurlp.Host
+		}
+	}
+
 	var dstSockAddr = sgsip.SGSIPSocketAddress{}
 	var dstURI = sgsip.SGSIPURI{}
 	if sgsip.SGSIPParseSocketAddress(dstAddr, &dstSockAddr) != sgsip.SGSIPRetOK {

--- a/sipexer.go
+++ b/sipexer.go
@@ -589,8 +589,8 @@ func init() {
 	flag.StringVar(&cliops.authalg, "auth-alg", cliops.authalg, "authenticate header selection: first | last | strong | algorithm-name")
 	flag.StringVar(&cliops.authuser, "au", cliops.authuser, "authentication user")
 	flag.StringVar(&cliops.authuser, "auth-user", cliops.authuser, "authentication user")
-	flag.StringVar(&cliops.authcsv, "acsv", cliops.authcsv, "path to a csv file with 'user,password' per line")
-	flag.StringVar(&cliops.authcsv, "auth-csv", cliops.authcsv, "path to a csv file with 'user,password' per line")
+	flag.StringVar(&cliops.authcsv, "acsv", cliops.authcsv, "path to a csv file with 'user,password[,target]'")
+	flag.StringVar(&cliops.authcsv, "auth-csv", cliops.authcsv, "path to a csv file with 'user,password[,target]'")
 	flag.StringVar(&cliops.body, "mb", cliops.body, "message body")
 	flag.StringVar(&cliops.body, "message-body", cliops.body, "message body")
 	flag.StringVar(&cliops.contacturi, "contact-uri", cliops.contacturi, "contact header uri")
@@ -841,6 +841,7 @@ func SIPExerRunScenario(tplstr string, scenarioIndex int) int {
 	var err error
 	var ok bool
 	var tret int
+	var target string
 
 	tplfields := make(map[string]any)
 
@@ -852,11 +853,14 @@ func SIPExerRunScenario(tplstr string, scenarioIndex int) int {
 		tplfields["fuser"] = ac.User
 		tplfields["authuser"] = ac.User
 		tplfields["authpassword"] = ac.Password
+		target = ac.Target
 	}
 
 	var wsurlp *url.URL = nil
 	dstAddr := "udp:127.0.0.1:5060"
-	if len(flag.Args()) > 0 {
+	if len(target) > 0 {
+		dstAddr = target
+	} else if len(flag.Args()) > 0 {
 		if len(flag.Args()) == 1 {
 			dstAddr = flag.Arg(0)
 			if strings.HasPrefix(dstAddr, "wss:") &&
@@ -1305,10 +1309,11 @@ func SIPExerRuntimeApply(st SIPExerRuntimeState) {
 	templateBody = st.templateBodyVal
 }
 
-// SIPExerAuthCredential is one 'user,password' row loaded from --auth-csv file
+// SIPExerAuthCredential is one 'user,password[,target]' row loaded from --auth-csv file
 type SIPExerAuthCredential struct {
 	User     string
 	Password string
+	Target   string
 }
 
 // authCredentials holds all rows loaded from --auth-csv file
@@ -1337,7 +1342,7 @@ func SIPExerLoadAuthCSV() int {
 	}
 	for i, rec := range records {
 		if len(rec) < 2 {
-			SIPExerPrintf(SIPExerLogError, "auth csv %s line %d: expected 'user,password', got %d field(s)\n",
+			SIPExerPrintf(SIPExerLogError, "auth csv %s line %d: expected 'user,password[,target]', got %d field(s)\n",
 				cliops.authcsv, i+1, len(rec))
 			return SIPExerErrAuthCSVFormat
 		}
@@ -1345,9 +1350,17 @@ func SIPExerLoadAuthCSV() int {
 		if len(user) == 0 {
 			continue
 		}
+
+		// csv row target is optional
+		var target string
+		if len(rec) >= 3 {
+			target = strings.TrimSpace(rec[2])
+		}
+
 		authCredentials = append(authCredentials, SIPExerAuthCredential{
 			User:     user,
 			Password: rec[1],
+			Target:   target,
 		})
 	}
 	if len(authCredentials) == 0 {


### PR DESCRIPTION
Main motivation for this was to allow round robin between different FQDNs corresponding to different tls certs that could be already loaded on the tested server(s). For some row(s) 3'rd column can be absent, and the cli target will be used for them. It also allows a mix of transports targets in the csv  (tested udp+tls targets together in same csv file)

Notes:
- in the separate commit, moved ws/wss normalization down in the code so it will also apply to csv row targets. Now will also apply to ```} else if len(flag.Args()) == 3 {``` too
- ~~did not test ws/wss~~ -> tested wss today with csv targets, works ok